### PR TITLE
feat: 주문 내역 조회 페이지 디자인 수정, 리다이렉트 경로 매핑, id로 조회하게 로직 수정

### DIFF
--- a/src/main/java/io/chaerin/cafemanagement/domain/order/controller/OrderController.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/order/controller/OrderController.java
@@ -43,7 +43,7 @@ public class OrderController {
         OrderResponseDto updatedOrder = orderService.updateOrder(id, request);
         model.addAttribute("order", updatedOrder);
         // 임의지정
-        return "order/result";
+        return "redirect:/orders";
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/io/chaerin/cafemanagement/domain/order/controller/OrderController.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/order/controller/OrderController.java
@@ -28,8 +28,8 @@ public class OrderController {
     }
 
     @GetMapping
-    public String getOrdersByEmail(@RequestParam String email, Model model) {
-        List<OrderResponseDto> orders = orderService.getOrdersByEmail(email);
+    public String getOrdersByEmail(HttpSession session, Model model) {
+        List<OrderResponseDto> orders = orderService.getOrdersByEmail(session);
         if (orders.isEmpty()) {
             return "redirect:/";
         }
@@ -50,6 +50,6 @@ public class OrderController {
     public String deleteOrder(@PathVariable Long id) {
         orderService.deleteOrder(id);
 
-        return "redirect:/products";
+        return "redirect:/orders";
     }
 }

--- a/src/main/java/io/chaerin/cafemanagement/domain/order/dto/OrderResponseDto.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/order/dto/OrderResponseDto.java
@@ -22,7 +22,7 @@ public class OrderResponseDto {
     private final String postCode;
     private final LocalDateTime createdAt;
     private final List<OrderItemResponseDto> orderItemList;
-
+    private int totalPrice;
 
     public OrderResponseDto(Order order) {
         this.email = order.getEmail();
@@ -42,6 +42,7 @@ public class OrderResponseDto {
         }
 
         this.orderItemList = items;
+        this.totalPrice = order.calculateTotalPrice ();
 
     }
 }

--- a/src/main/java/io/chaerin/cafemanagement/domain/order/entity/Order.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/order/entity/Order.java
@@ -62,4 +62,9 @@ public class Order {
         this.orderItemList.add(orderItem);
     }
 
+    public Integer calculateTotalPrice() {
+        return orderItemList.stream()
+                .mapToInt(item -> item.getProduct().getPrice() * item.getQuantity())
+                .sum();
+    }
 }

--- a/src/main/java/io/chaerin/cafemanagement/domain/order/repository/OrderRepository.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/order/repository/OrderRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
-    List<Order> findByEmail(String email);
+    List<Order> findByUserUserId(Long userId);
 }

--- a/src/main/java/io/chaerin/cafemanagement/domain/order/service/OrderService.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/order/service/OrderService.java
@@ -61,10 +61,15 @@ public class OrderService {
         return new OrderResponseDto(savedOrder);
     }
 
-    public List<OrderResponseDto> getOrdersByEmail(String email) {
-        List<Order> orders = orderRepository.findByEmail(email);
+    public List<OrderResponseDto> getOrdersByEmail(HttpSession session) {
+        Object loginUser = session.getAttribute("loginUser");
+        if (loginUser == null) {
+            throw new IllegalStateException("로그인 후 이용해주세요.");
+        }
+        Long userId = ((User) loginUser).getUserId();
+        List<Order> orders = orderRepository.findByUserUserId(userId);
+
         List<OrderResponseDto> dtoList = new ArrayList<>();
-        // dto 를 바로 가져와서... => 고민좀 해보고.
         for (Order order : orders) {
             dtoList.add(new OrderResponseDto(order));
         }

--- a/src/main/java/io/chaerin/cafemanagement/domain/review/controller/ReviewController.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/review/controller/ReviewController.java
@@ -3,6 +3,8 @@ package io.chaerin.cafemanagement.domain.review.controller;
 import io.chaerin.cafemanagement.domain.review.dto.ReviewCreateRequestDto;
 import io.chaerin.cafemanagement.domain.review.dto.ReviewResponseDto;
 import io.chaerin.cafemanagement.domain.review.service.ReviewService;
+import io.chaerin.cafemanagement.domain.user.entity.User;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -23,7 +25,8 @@ public class ReviewController {
             @PathVariable Long productId,
             @Valid @ModelAttribute ReviewCreateRequestDto requestDto,
             BindingResult bindingResult,
-            Model model
+            Model model,
+            HttpSession session
     ) {
         if (bindingResult.hasErrors()) {
             model.addAttribute("errors", bindingResult);
@@ -31,8 +34,11 @@ public class ReviewController {
             return "review/form";
         }
 
-        //TODO: 추후 유저 정보 받아오도록 변경 예정
-        Long userId = 1L;
+        Object loginUser = session.getAttribute("loginUser");
+        if (loginUser == null) {
+            throw new IllegalStateException("로그인 후 이용해주세요.");
+        }
+        Long userId = ((User) loginUser).getUserId();
 
         reviewService.save(requestDto, productId, userId);
 
@@ -54,12 +60,16 @@ public class ReviewController {
     @GetMapping
     public String getReviewList(
             @PathVariable Long productId,
-            Model model
+            Model model,
+            HttpSession session
     ) {
         List<ReviewResponseDto> reviewList = reviewService.getReviewList(productId);
 
-        //TODO: 추후 유저 정보 받아오도록 변경 예정
-        Long currentUserId = 1L;
+        Object loginUser = session.getAttribute("loginUser");
+        if (loginUser == null) {
+            throw new IllegalStateException("로그인 후 이용해주세요.");
+        }
+        Long currentUserId = ((User) loginUser).getUserId();
 
         model.addAttribute("productId", productId);
         model.addAttribute("currentUserId", currentUserId);
@@ -71,11 +81,15 @@ public class ReviewController {
     @DeleteMapping("/delete/{reviewId}")
     public String deleteReview(
             @PathVariable Long reviewId,
-            @PathVariable Long productId
+            @PathVariable Long productId,
+            HttpSession session
     ) throws IllegalAccessException {
 
-        //TODO: 추후 유저 정보 받아오도록 변경 예정
-        Long userId = 1L;
+        Object loginUser = session.getAttribute("loginUser");
+        if (loginUser == null) {
+            throw new IllegalStateException("로그인 후 이용해주세요.");
+        }
+        Long userId = ((User) loginUser).getUserId();
 
         reviewService.deleteReview(reviewId, userId);
 

--- a/src/main/java/io/chaerin/cafemanagement/domain/review/controller/ReviewController.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/review/controller/ReviewController.java
@@ -28,8 +28,6 @@ public class ReviewController {
         if (bindingResult.hasErrors()) {
             model.addAttribute("errors", bindingResult);
 
-            // 유효성 검증 실패 시 반환될 테스트용 페이지
-            // html 추가 시, 리뷰 작성 페이지로 변경 예정
             return "review/form";
         }
 

--- a/src/main/java/io/chaerin/cafemanagement/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/review/dto/ReviewResponseDto.java
@@ -4,11 +4,14 @@ import io.chaerin.cafemanagement.domain.review.entity.Review;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 public class ReviewResponseDto {
     private Long reviewId;
     private String content;
+    private LocalDateTime createdAt;
     private Long productId;
     private Long userId;
 
@@ -16,14 +19,16 @@ public class ReviewResponseDto {
         return ReviewResponseDto.builder()
                 .reviewId(review.getReviewId())
                 .content(review.getContent())
+                .createdAt(review.getCreatedAt())
                 .productId(review.getProduct().getProductId())
                 .userId(review.getUser().getUserId())
                 .build();
     }
 
-    public ReviewResponseDto(Long reviewId, String content, Long productId, Long userId) {
+    public ReviewResponseDto(Long reviewId, String content, LocalDateTime createdAt, Long productId, Long userId) {
         this.reviewId = reviewId;
         this.content = content;
+        this.createdAt = createdAt;
         this.productId = productId;
         this.userId = userId;
     }

--- a/src/main/java/io/chaerin/cafemanagement/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/review/dto/ReviewResponseDto.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 public class ReviewResponseDto {
     private Long reviewId;
     private String content;
+    private String username;
     private LocalDateTime createdAt;
     private Long productId;
     private Long userId;
@@ -19,15 +20,17 @@ public class ReviewResponseDto {
         return ReviewResponseDto.builder()
                 .reviewId(review.getReviewId())
                 .content(review.getContent())
+                .username(review.getUser().getUserName())
                 .createdAt(review.getCreatedAt())
                 .productId(review.getProduct().getProductId())
                 .userId(review.getUser().getUserId())
                 .build();
     }
 
-    public ReviewResponseDto(Long reviewId, String content, LocalDateTime createdAt, Long productId, Long userId) {
+    public ReviewResponseDto(Long reviewId, String content, String username, LocalDateTime createdAt, Long productId, Long userId) {
         this.reviewId = reviewId;
         this.content = content;
+        this.username = username;
         this.createdAt = createdAt;
         this.productId = productId;
         this.userId = userId;

--- a/src/main/java/io/chaerin/cafemanagement/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/review/dto/ReviewResponseDto.java
@@ -17,7 +17,7 @@ public class ReviewResponseDto {
                 .reviewId(review.getReviewId())
                 .content(review.getContent())
                 .productId(review.getProduct().getProductId())
-                .userId(review.getUser().getId())
+                .userId(review.getUser().getUserId())
                 .build();
     }
 

--- a/src/main/java/io/chaerin/cafemanagement/domain/review/service/ReviewService.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/review/service/ReviewService.java
@@ -65,7 +65,7 @@ public class ReviewService {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 리뷰가 없습니다."));
 
-        if (!Objects.equals(review.getUser().getId(), userId)) {
+        if (!Objects.equals(review.getUser().getUserId(), userId)) {
             throw new IllegalAccessException("본인이 작성한 리뷰만 삭제할 수 있습니다.");
         }
 

--- a/src/main/java/io/chaerin/cafemanagement/domain/review/service/ReviewService.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/review/service/ReviewService.java
@@ -25,7 +25,6 @@ public class ReviewService {
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
 
-    // 후기 작성
     @Transactional
     public ReviewResponseDto save(ReviewCreateRequestDto requestDto, Long productId, Long userId) {
 
@@ -49,7 +48,6 @@ public class ReviewService {
 
     }
 
-    // 후기 조회
     @Transactional
     public List<ReviewResponseDto> getReviewList(Long productId) {
         List<Review> reviewList = reviewRepository.findByProduct_ProductIdOrderByCreatedAt(productId);
@@ -59,7 +57,6 @@ public class ReviewService {
                 .collect(Collectors.toList());
     }
 
-    // 후기 삭제
     @Transactional
     public void deleteReview(Long reviewId, Long userId) throws IllegalAccessException {
         Review review = reviewRepository.findById(reviewId)

--- a/src/main/java/io/chaerin/cafemanagement/domain/user/controller/UserController.java
+++ b/src/main/java/io/chaerin/cafemanagement/domain/user/controller/UserController.java
@@ -34,6 +34,11 @@ public class UserController {
         return "redirect:/login";
     }
 
+    @GetMapping("/join")
+    public String showJoinForm() {
+        return "join";  // templates/join.html을 띄워준다
+    }
+
     // 로그인 API
     @PostMapping("/login")
     public String login(@ModelAttribute UserLoginRequestDto loginRequest,
@@ -44,7 +49,7 @@ public class UserController {
 
         log.info("user.getUserId() = {}", user.getUserName());
 
-        return "redirect:/";
+        return "redirect:/products";
     }
 
     // 로그아웃 API

--- a/src/main/resources/static/css/order_style.css
+++ b/src/main/resources/static/css/order_style.css
@@ -1,26 +1,39 @@
+/* 전체 배경 */
+body {
+    background-color: #f5f5f5;
+    font-family: 'Noto Sans KR', sans-serif;
+    margin: 0;
+    padding: 0;
+}
 
+/* 주문 리스트 전체 */
+.orders {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+/* 주문 카드 */
 .container {
-    max-width: 600px;
-    margin: 0 auto;
+    max-width: 640px;
+    margin: 20px auto;
     background-color: white;
     border-radius: 16px;
-    padding: 20px;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    padding: 24px;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.05);
+    transition: all 0.3s ease;
 }
-.content {
-    padding-top: 20px;
+
+.container:hover {
+    transform: translateY(-5px);
 }
-hr {
-    opacity: 50%;
-}
-.light-hr {
-    opacity: 20%;
-}
+
+
 /* 헤더 */
 .header {
     background-color: #ffffff;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-    padding: 12px 20px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.03);
+    padding: 16px 24px;
 }
 
 .header-container {
@@ -32,7 +45,7 @@ hr {
 }
 
 .logo img {
-    height: 32px;
+    height: 36px;
 }
 
 .order-button button {
@@ -42,45 +55,61 @@ hr {
 }
 
 .order-button img {
-    width: 24px;
-    height: 24px;
+    width: 28px;
+    height: 28px;
     filter: grayscale(100%);
 }
 
-/* 상단 간략 배송 정보 css */
+/* 상단 주문 요약 */
 .top-section {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    background-color: #f0f0f0;
+    background-color: #f0f2f5;
     border-radius: 12px;
-    padding: 12px;
+    padding: 12px 16px;
 }
+
 .top-section-left {
     display: flex;
     align-items: center;
 }
+
 .top-section-left img {
     width: 48px;
     height: 48px;
-    border-radius: 8px;
+    border-radius: 12px;
     object-fit: cover;
     margin-right: 12px;
 }
+
 .top-section-order .date {
     font-weight: bold;
-}
-.status {
-    font-weight: bold;
-    font-size: 17px;
+    color: #555;
 }
 
-/* 주문 상품 목록 css */
+.number {
+    font-size: 14px;
+    color: #888;
+}
+
+.status {
+    font-weight: bold;
+    font-size: 16px;
+    color: #4caf50;
+}
+
+/* 상품 리스트 */
 .item {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 6px;
+    padding: 8px 0;
+    border-bottom: 1px solid #eee;
+}
+
+.item:last-child {
+    border-bottom: none;
 }
 
 .item-right {
@@ -93,38 +122,66 @@ hr {
 .price {
     min-width: 60px;
 }
+.buy-info {
+    margin-top: 20px;
+}
+.buy-info-title {
+    font-weight: bold;
+    font-size: 18px;
+    margin-bottom: 8px;
+}
 .buy-info-email,
 .buy-info-address {
     margin-bottom: 6px;
+    color: #555;
+    font-size: 14px;
 }
 
 /* 버튼, 결제 정보 css */
 .botton-section {
+    margin-top: 20px;
     display: flex;
     justify-content: space-between;
     align-items: center;
 }
+
 .buttons button {
-    padding: 6px 12px;
-    font-size: 13px;
-    color: white;
+    padding: 8px 16px;
+    font-size: 14px;
     border: none;
-    border-radius: 6px;
+    border-radius: 8px;
     cursor: pointer;
-    margin-right: 6px;
+    transition: background-color 0.3s ease;
 }
 
 .buttons .edit {
-    background-color: black;
+    background-color: #4a4a4a;
+    color: #fff;
 }
 
 .buttons .delete {
-    background-color: orangered;
+    background-color: #ff5c5c;
+    color: #fff;
 }
 
-.total-price,
-.buy-info-title {
+.buttons .delete:hover {
+    background-color: #ff1f1f;
+}
+
+.buttons form {
+    display: inline;
+}
+
+/* 총 금액 강조 */
+.total-price {
     font-weight: bold;
-    font-size: 18px;
-    margin-bottom: 6px;
+    font-size: 20px;
+    color: #222;
+}
+
+/* 구분선 */
+hr {
+    border: none;
+    border-top: 1px solid #ddd;
+    margin: 16px 0;
 }

--- a/src/main/resources/static/css/review_style.css
+++ b/src/main/resources/static/css/review_style.css
@@ -1,0 +1,134 @@
+body {
+    font-family: 'Noto Sans KR', sans-serif;
+    background-color: #f5f5f5;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+/* 버튼 섹션 */
+.buttons {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 30px;
+}
+
+.buttons form button {
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    font-size: 16px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    margin-top: 20px;
+}
+
+.buttons form button:hover {
+    background-color: #45a049;
+}
+
+/* 리뷰 리스트 전체 */
+.review-list {
+    background-color: white;
+    width: 600px;
+    padding: 30px;
+    border-radius: 16px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+/* 각각의 리뷰 아이템 */
+.review-list ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.review-list li {
+    border-bottom: 1px solid #e0e0e0;
+    padding: 20px 0;
+}
+
+.review-list li:last-child {
+    border-bottom: none;
+}
+
+/* 작성일, 내용 */
+.review-list div {
+    margin-bottom: 8px;
+    font-size: 16px;
+}
+
+.review-date {
+    color: #222222;
+}
+
+.review-content {
+    font-size: larger;
+}
+
+/* 삭제 버튼 */
+.review-list form button {
+    background-color: #ff5c5c;
+    color: white;
+    border: none;
+    padding: 6px 12px;
+    font-size: 14px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.review-list form button:hover {
+    background-color: #ff1f1f;
+}
+
+/* 리뷰 작성 폼 (review/form.html) */
+.form-container {
+    background-color: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    max-width: 600px;
+    margin: 40px auto;
+    padding: 30px;
+    font-family: 'Noto Sans KR', sans-serif;
+}
+
+.form-container form {
+    display: flex;
+    flex-direction: column;
+}
+
+.form-container label {
+    margin-bottom: 8px;
+    font-weight: bold;
+    font-size: 16px;
+}
+
+.form-input {
+    height: 150px;
+    padding: 10px;
+    font-size: 14px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    resize: none;
+    margin-bottom: 20px;
+}
+
+.save {
+    background-color: #4CAF50;
+    border: none;
+    color: white;
+    padding: 10px 20px;
+    font-size: 15px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.save:hover {
+    background-color: #45a049;
+}

--- a/src/main/resources/static/css/review_style.css
+++ b/src/main/resources/static/css/review_style.css
@@ -13,10 +13,10 @@ body {
     display: flex;
     gap: 10px;
     margin-bottom: 30px;
+    align-content: space-evenly;
 }
 
 .buttons form button {
-    background-color: #4CAF50;
     color: white;
     border: none;
     padding: 10px 20px;
@@ -27,8 +27,15 @@ body {
     margin-top: 20px;
 }
 
-.buttons form button:hover {
+
+.buttons .create {
+    background-color: #4CAF50;
+}
+.buttons create:hover {
     background-color: #45a049;
+}
+.buttons .back {
+    background-color: #4a4a4a;
 }
 
 /* 리뷰 리스트 전체 */
@@ -62,12 +69,22 @@ body {
     font-size: 16px;
 }
 
+.review-header {
+    display: flex;
+    justify-content: space-between;
+}
+
+.review-username {
+    font-weight: bold;
+    color: #333;
+}
+
 .review-date {
-    color: #222222;
+    color: #555;
 }
 
 .review-content {
-    font-size: larger;
+    font-size: 16px;
 }
 
 /* 삭제 버튼 */

--- a/src/main/resources/templates/join.html
+++ b/src/main/resources/templates/join.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>회원가입</title>
+</head>
+<body>
+<h1>회원가입</h1>
+<form th:action="@{/join}" method="post">
+    <label for="userName">아이디</label>
+    <input type="text" id="userName" name="userName" required><br>
+
+    <label for="password">비밀번호</label>
+    <input type="password" id="password" name="password" required><br>
+
+    <button type="submit">회원가입</button>
+</form>
+
+<a th:href="@{/login}">이미 계정이 있으신가요? 로그인</a>
+</body>
+</html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -13,8 +13,8 @@
             <div class="title">로그인</div>
             <br>
             <div>
-                <label for="userId">아이디</label>
-                <input class="form-control" type="text" name="userId" id="userId" required>
+                <label for="userName">아이디</label>
+                <input class="form-control" type="text" name="userName" id="userName" required>
             </div>
             <div>
                 <label for="password">비밀번호</label>

--- a/src/main/resources/templates/order/list.html
+++ b/src/main/resources/templates/order/list.html
@@ -1,102 +1,136 @@
-<!-- 주문을 조회하는 페이지 -->
+<!-- 주문을 조회하는 페이지 (폼 방식, 커스텀 인풋 디자인 개선) -->
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <link rel="stylesheet" href="css/order_style.css" />
+    <link rel="stylesheet" href="/css/order_style.css" />
     <title>주문 목록</title>
+    <style>
+        /* ---------------- 레이아웃 ---------------- */
+        .buttons{display:flex;gap:8px;align-items:center}
+        .buttons form{margin:0}
+        .botton-section{display:flex;justify-content:space-between;align-items:center}
+
+        /* ---------------- 인풋 공통 ---------------- */
+        .pretty-input{width:100%;border:none;border-bottom:1px dashed #c4c4c4;background:transparent;padding:4px 2px;font-size:14px;transition:all .15s ease;box-sizing:border-box}
+        .pretty-input:focus{outline:none;border-bottom:1px solid #4caf50;box-shadow:0 1px 0 0 #4caf50}
+        input[type=number].pretty-input::-webkit-inner-spin-button,
+        input[type=number].pretty-input::-webkit-outer-spin-button{appearance:none;margin:0}
+
+        /* 수량 인풋 전용 크기 */
+        .quantity-input{max-width:24px;text-align:center}
+
+        /* 보기·편집 전환 */
+        .edit-field{display:none}
+
+        /* 구매 정보 라인 정렬 */
+        .buy-info-line{display:flex;align-items:center;gap:6px;margin-bottom:8px}
+        .buy-info-line strong{width:60px;font-size:14px;color:#333}
+        .buy-info-line .view-field{flex:1}
+        .buy-info-line .edit-field{flex:1}
+    </style>
 </head>
 <body>
 
 <header class="header">
     <div class="header-container">
-        <!-- 로고 -->
         <div class="logo">
-            <img
-                    src="https://emojis.slackmojis.com/emojis/images/1643514532/5264/coding.gif?1643514532"
-                    alt="로고"
-                    onclick="location.href='/products'"
-            />
+            <img src="https://emojis.slackmojis.com/emojis/images/1643514532/5264/coding.gif?1643514532" alt="로고" onclick="location.href='/products'"/>
         </div>
-
-        <!-- 우측 아이콘 버튼 -->
-        <div class="order-button">
-            <button onclick="location.href='/orders'">
-                <img
-                        src="https://cdn-icons-png.flaticon.com/512/3144/3144456.png"
-                        alt="주문 목록"
-                />
-            </button>
-        </div>
+        <div class="order-button"><button onclick="location.href='/orders'"><img src="https://cdn-icons-png.flaticon.com/512/3144/3144456.png" alt="주문 목록"/></button></div>
     </div>
 </header>
+
 <main class="content">
     <div class="order-list">
         <ul class="orders">
+            <li th:each="order : ${orders}">
+                <!-- 주문 한 건을 폼으로 감싸기 -->
+                <form th:action="@{'/orders/' + ${order.orderId}}" method="post" class="container" th:attr="data-order-id=${order.orderId}">
+                    <input type="hidden" name="_method" value="put"/>
 
-            <li th:each="order: ${orders}">
-                <div class="container">
-                    <!-- 상단 간략 배송 정보 -->
+                    <!-- 상단 -->
                     <div class="top-section">
                         <div class="top-section-left">
-                            <img
-                                    src="https://emojis.slackmojis.com/emojis/images/1643514596/5999/meow_party.gif?1643514596"
-                                    alt="상품 이미지"
-                            />
+                            <img src="https://emojis.slackmojis.com/emojis/images/1643514596/5999/meow_party.gif" alt="상품 이미지"/>
                             <div class="top-section-order">
-                                <div th:text="${#temporals.format(order.createdAt, 'yyyy-MM-dd HH:mm')}" class="date"></div>
-                                <div class="number">주문번호: [[${order.orderId}]]</div>
+                                <div class="date" th:text="${#temporals.format(order.createdAt,'yyyy-MM-dd HH:mm')}"></div>
+                                <div class="number">주문번호: <span th:text="${order.orderId}"></span></div>
                             </div>
                         </div>
                         <div class="status">배송중</div>
                     </div>
-                    <hr />
+                    <hr/>
 
-                    <!-- 주문 상품 목록 -->
+                    <!-- 상품 리스트 -->
                     <div class="item-list">
                         <ul class="items">
-                            <li th:each="item: ${order.orderItemList}">
+                            <li th:each="item,stat : ${order.orderItemList}">
                                 <div class="item">
                                     <span th:text="${item.productName}"></span>
-                                    <span class="item-right">
-                                  <span class="quantity">[[${item.quantity}]]개</span>
-<!--                                    각 아이템 개수당 가결-->
-                                  <span class="price">[[${item.price}]]원</span>
-                                </span>
+
+                                    <!-- 표시용 수량/가격 -->
+                                    <span class="item-right view-field">
+                                        <span class="quantity-text" th:text="${item.quantity + '개'}"></span>
+                                        <span class="price" th:text="${item.price + '원'}"></span>
+                                    </span>
+
+                                    <!-- 편집용 input -->
+                                    <span class="item-right edit-field">
+                                        <input type="number" min="1" class="pretty-input quantity-input" th:name="${'orderItem[' + stat.index + '].quantity'}" th:value="${item.quantity}"/>
+                                        <span class="price" th:text="${item.price + '원'}"></span>
+                                    </span>
+                                    <input type="hidden" th:name="${'orderItem[' + stat.index + '].productId'}" th:value="${item.productId}"/>
                                 </div>
                             </li>
                         </ul>
                     </div>
-                    <hr />
+                    <hr/>
 
                     <!-- 구매 정보 -->
                     <div class="buy-info">
                         <div class="buy-info-title">구매 정보</div>
-                        <div class="buy-info-email">
-                            <strong>이메일:</strong> [[${order.email}]]
+
+                        <div class="buy-info-line">
+                            <strong>이메일:</strong>
+                            <span class="view-field" th:text="${order.email}"></span>
+                            <span class="edit-field" style="width:100%"><input class="pretty-input email-input" type="text" name="email" th:value="${order.email}"/></span>
                         </div>
-                        <div class="buy-info-address">
-                            <strong>주소:</strong> [[${order.address}]]
+
+                        <div class="buy-info-line">
+                            <strong>주소:</strong>
+                            <span class="view-field" th:text="${order.address}"></span>
+                            <span class="edit-field" style="width:100%"><input class="pretty-input address-input" type="text" name="address" th:value="${order.address}"/></span>
                         </div>
                     </div>
-                    <hr />
+                    <hr/>
 
-                    <!-- 하단 버튼 + 총 금액 -->
+                    <!-- 하단 버튼 & 총액 -->
                     <div class="botton-section">
                         <div class="buttons">
-<!--                            <button class="edit">수정</button>-->
+                            <button type="button" class="edit" onclick="enableEditMode(this)">수정</button>
+                            <button type="submit" class="save" style="display:none">수정 완료</button>
                             <form th:action="@{'/orders/' + ${order.orderId}}" method="post" onsubmit="return confirm('정말 삭제하시겠습니까?');">
-                                <input type="hidden" name="_method" value="delete" />
-                                <button class="delete" type="submit">주문 취소</button>
+                                <input type="hidden" name="_method" value="delete"/>
+                                <button type="submit" class="delete">취소</button>
                             </form>
                         </div>
-                        <div class="total-price">[[${order.totalPrice}]]원</div>
+                        <div class="total-price" th:text="${order.totalPrice + '원'}"></div>
                     </div>
-                </div>
+                </form>
             </li>
         </ul>
     </div>
 </main>
 
+<script>
+    function enableEditMode(btn){
+        const form=btn.closest('form');
+        form.querySelectorAll('.view-field').forEach(el=>el.style.display='none');
+        form.querySelectorAll('.edit-field').forEach(el=>el.style.display='inline-block');
+        btn.style.display='none';
+        form.querySelector('.save').style.display='inline-block';
+    }
+</script>
 
 </body>
 </html>

--- a/src/main/resources/templates/order/list.html
+++ b/src/main/resources/templates/order/list.html
@@ -14,12 +14,13 @@
             <img
                     src="https://emojis.slackmojis.com/emojis/images/1643514532/5264/coding.gif?1643514532"
                     alt="로고"
+                    onclick="location.href='/products'"
             />
         </div>
 
         <!-- 우측 아이콘 버튼 -->
         <div class="order-button">
-            <button onclick="location.href=''">
+            <button onclick="location.href='/orders'">
                 <img
                         src="https://cdn-icons-png.flaticon.com/512/3144/3144456.png"
                         alt="주문 목록"
@@ -59,7 +60,7 @@
                                     <span class="item-right">
                                   <span class="quantity">[[${item.quantity}]]개</span>
 <!--                                    각 아이템 개수당 가결-->
-                                  <span class="price">5,000원</span>
+                                  <span class="price">[[${item.price}]]원</span>
                                 </span>
                                 </div>
                             </li>
@@ -82,10 +83,13 @@
                     <!-- 하단 버튼 + 총 금액 -->
                     <div class="botton-section">
                         <div class="buttons">
-                            <button class="edit">수정</button>
-                            <button class="delete">삭제</button>
+<!--                            <button class="edit">수정</button>-->
+                            <form th:action="@{'/orders/' + ${order.orderId}}" method="post" onsubmit="return confirm('정말 삭제하시겠습니까?');">
+                                <input type="hidden" name="_method" value="delete" />
+                                <button class="delete" type="submit">주문 취소</button>
+                            </form>
                         </div>
-                        <div class="total-price">총 금액: 27,000원</div>
+                        <div class="total-price">[[${order.totalPrice}]]원</div>
                     </div>
                 </div>
             </li>

--- a/src/main/resources/templates/order/list.html
+++ b/src/main/resources/templates/order/list.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" href="/css/order_style.css" />
     <title>주문 목록</title>
     <style>
+        /* update 로직 => input 박스 생성을 위한 스타일 영역 */
         /* ---------------- 레이아웃 ---------------- */
         .buttons{display:flex;gap:8px;align-items:center}
         .buttons form{margin:0}

--- a/src/main/resources/templates/order/result.html
+++ b/src/main/resources/templates/order/result.html
@@ -83,7 +83,7 @@
 <!--                <button class="edit" id="edit">수정</button>-->
                 <form th:action="@{'/orders/' + ${order.orderId}}" method="post" onsubmit="return confirm('정말 삭제하시겠습니까?');">
                     <input type="hidden" name="_method" value="delete" />
-                    <button class="delete" type="submit">주문 취소</button>
+                    <button class="delete" type="submit">취소</button>
                 </form>
 
             </div>

--- a/src/main/resources/templates/order/result.html
+++ b/src/main/resources/templates/order/result.html
@@ -15,12 +15,13 @@
             <img
                     src="https://emojis.slackmojis.com/emojis/images/1643514532/5264/coding.gif?1643514532"
                     alt="로고"
+                    onclick="location.href='/products'"
             />
         </div>
 
         <!-- 우측 아이콘 버튼 -->
         <div class="order-button">
-            <button onclick="location.href=''">
+            <button onclick="location.href='/orders'">
                 <img
                         src="https://cdn-icons-png.flaticon.com/512/3144/3144456.png"
                         alt="주문 목록"
@@ -56,7 +57,7 @@
                         <span th:text="${item.productName}"></span>
                         <span class="item-right">
                             <span class="quantity">[[${item.quantity}]]개</span>
-
+                            <span class="price">[[${item.price}]]원</span>
                         </span>
                     </div>
                 </li>
@@ -79,14 +80,14 @@
         <!-- 하단 버튼 + 총 금액 -->
         <div class="botton-section">
             <div class="buttons">
-                <button class="edit" id="edit">수정</button>
+<!--                <button class="edit" id="edit">수정</button>-->
                 <form th:action="@{'/orders/' + ${order.orderId}}" method="post" onsubmit="return confirm('정말 삭제하시겠습니까?');">
                     <input type="hidden" name="_method" value="delete" />
-                    <button class="delete" type="submit">삭제</button>
+                    <button class="delete" type="submit">주문 취소</button>
                 </form>
 
             </div>
-            <div class="total-price" id="total-price">총 금액: 27,000원</div>
+            <div class="total-price">[[${order.totalPrice}]]원</div>
         </div>
     </div>
 

--- a/src/main/resources/templates/product/cart.html
+++ b/src/main/resources/templates/product/cart.html
@@ -54,20 +54,6 @@
     </div>
     <hr>
     <div id = "cartList"></div>
-    <!-- <div class="row">
-        <h5 class="col p-0">
-            아메리카노
-        </h5>
-        <h6 class="col">
-            <button>
-                <img src="./assets/product_minus_icon.png">
-            </button>
-            <span class="badge bg-dark">2개</span>
-            <button>
-                <img src="./assets/product_add_small_icon.png">
-            </button>
-        </h6>
-    </div> -->
     <hr>
     <form id="orderForm" method="post" action="/orders">
       <div class="mb-3">

--- a/src/main/resources/templates/review/form.html
+++ b/src/main/resources/templates/review/form.html
@@ -17,5 +17,3 @@
 </div>
 </body>
 </html>
-
-fix: 리뷰 목록, 작성 css 추가

--- a/src/main/resources/templates/review/form.html
+++ b/src/main/resources/templates/review/form.html
@@ -2,17 +2,18 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>리뷰 작성</title>
+    <link rel="stylesheet" href="/css/review_style.css">
 </head>
 <body>
+<div class="form-container">
+    <form th:action="@{'/products/' + ${productId} + '/reviews'}" method="post" th:object="${reviewCreateRequestDto}">
 
-<form th:action="@{'/products/' + ${productId} + '/reviews'}" method="post" th:object="${reviewCreateRequestDto}">
-
-  <label>내용: </label>
-  <textarea th:field="*{content}"></textarea>
-  <br />
-  <button type="submit">등록</button>
-</form>
-
+      <label>내용: </label>
+      <textarea class="form-input" th:field="*{content}"></textarea>
+      <br />
+      <button class="save" type="submit">등록</button>
+    </form>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/review/form.html
+++ b/src/main/resources/templates/review/form.html
@@ -17,3 +17,5 @@
 </div>
 </body>
 </html>
+
+fix: 리뷰 목록, 작성 css 추가

--- a/src/main/resources/templates/review/list.html
+++ b/src/main/resources/templates/review/list.html
@@ -9,9 +9,9 @@
 
 
   <div class="buttons">
-<!--    <form th:action="@{'/products'}" method="get">-->
-<!--      <button type="submit" >나가기</button>-->
-<!--    </form>-->
+    <form th:action="@{'/products'}" method="get">
+      <button type="submit" class="back" >상품으로 돌아가기</button>
+    </form>
     <form th:action="@{'/products/' + ${productId} + '/reviews/form'}" method="get">
       <button type="submit" class="create">리뷰 작성</button>
     </form>
@@ -21,7 +21,10 @@
   <div class="review-list">
     <ul>
       <li th:each="review: ${reviews}">
-        <div th:text="${#temporals.format(review.createdAt,'yyyy-MM-dd HH:mm')}" class="review-date">날짜</div>
+        <div class="review-detail">
+          <span th:text="${review.username}" class="review-username"></span>
+          <span th:text="${#temporals.format(review.createdAt,'yyyy-MM-dd HH:mm')}" class="review-date">날짜</span>
+        </div>
         <div th:text="${review.content}" class="review-content">내용</div>
 
         <form th:if="${review.getUserId()} == ${currentUserId}"

--- a/src/main/resources/templates/review/list.html
+++ b/src/main/resources/templates/review/list.html
@@ -2,17 +2,18 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>리뷰 목록</title>
+    <link rel="stylesheet" href="/css/review_style.css">
 </head>
 <body>
 
 
   <div class="buttons">
-    <form th:action="@{'/products'}" method="get">
-      <button type="submit">나가기</button>
-    </form>
+<!--    <form th:action="@{'/products'}" method="get">-->
+<!--      <button type="submit" >나가기</button>-->
+<!--    </form>-->
     <form th:action="@{'/products/' + ${productId} + '/reviews/form'}" method="get">
-      <button type="submit">리뷰 작성</button>
+      <button type="submit" class="create">리뷰 작성</button>
     </form>
   </div>
 
@@ -20,13 +21,14 @@
   <div class="review-list">
     <ul>
       <li th:each="review: ${reviews}">
-        <div th:text="${review.content}"></div>
+        <div th:text="${#temporals.format(review.createdAt,'yyyy-MM-dd HH:mm')}" class="review-date">날짜</div>
+        <div th:text="${review.content}" class="review-content">내용</div>
 
         <form th:if="${review.getUserId()} == ${currentUserId}"
               th:action="@{'/products/' + ${productId} + '/reviews/delete/' + ${review.getReviewId()}}" method="post"
               onsubmit="return confirm('정말 삭제하시겠습니까?');">
           <input type="hidden" name="_method" value="delete" />
-          <button type="submit">삭제</button>
+          <button type="submit" class="delete">삭제</button>
         </form>
         
         <br>

--- a/src/test/java/io/chaerin/cafemanagement/domain/review/controller/ReviewControllerMockTests.java
+++ b/src/test/java/io/chaerin/cafemanagement/domain/review/controller/ReviewControllerMockTests.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,7 +49,7 @@ class ReviewControllerMockTests {
         // doNothing은 void 메소드에만 사용 가능
 //        doNothing().when(reviewService).save(requestDto, productId);
 
-        ReviewResponseDto responseDto = new ReviewResponseDto(1L, requestDto.getContent(), productId, userId);
+        ReviewResponseDto responseDto = new ReviewResponseDto(1L, requestDto.getContent(), LocalDateTime.now(), productId, userId);
 
         doReturn(responseDto).when(reviewService).save(requestDto, productId, userId);
 
@@ -86,8 +87,8 @@ class ReviewControllerMockTests {
         Long userId = 1L;
 
         List<ReviewResponseDto> reviewList = List.of(
-                new ReviewResponseDto(1L, "짱맛있다", productId, userId),
-                new ReviewResponseDto(2L, "짱맛없다", productId,userId)
+                new ReviewResponseDto(1L, "짱맛있다", LocalDateTime.now(), productId, userId),
+                new ReviewResponseDto(2L, "짱맛없다", LocalDateTime.now(), productId,userId)
         );
 
         // doReturn().when(): 이 값을 리턴하라 (Mockito)

--- a/src/test/java/io/chaerin/cafemanagement/domain/review/controller/ReviewControllerMockTests.java
+++ b/src/test/java/io/chaerin/cafemanagement/domain/review/controller/ReviewControllerMockTests.java
@@ -49,7 +49,7 @@ class ReviewControllerMockTests {
         // doNothing은 void 메소드에만 사용 가능
 //        doNothing().when(reviewService).save(requestDto, productId);
 
-        ReviewResponseDto responseDto = new ReviewResponseDto(1L, requestDto.getContent(), LocalDateTime.now(), productId, userId);
+        ReviewResponseDto responseDto = new ReviewResponseDto(1L, requestDto.getContent(),"1234", LocalDateTime.now(), productId, userId);
 
         doReturn(responseDto).when(reviewService).save(requestDto, productId, userId);
 
@@ -87,8 +87,8 @@ class ReviewControllerMockTests {
         Long userId = 1L;
 
         List<ReviewResponseDto> reviewList = List.of(
-                new ReviewResponseDto(1L, "짱맛있다", LocalDateTime.now(), productId, userId),
-                new ReviewResponseDto(2L, "짱맛없다", LocalDateTime.now(), productId,userId)
+                new ReviewResponseDto(1L, "짱맛있다", "1234", LocalDateTime.now(), productId, userId),
+                new ReviewResponseDto(2L, "짱맛없다", "1234",LocalDateTime.now(), productId,userId)
         );
 
         // doReturn().when(): 이 값을 리턴하라 (Mockito)


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Isuue Number) -->
feat/review가 merge 되지 않아서 feat/review 에서 분기 해서 만든 branch 입니다.
feat/review 관련 pr merge 후, 이 pr merge 하고 dev로 merge 하면 될 것 같습니다.

1. 주문 내역 조회 페이지의 디자인 수정. (구조는 동일한데, 음영과 같은 내역 변경했습니다)
2. 좌측과 우측 아이콘 경로 매핑 ( 좌측: 구매 페이지, 우측: 전체 주문 내역 조회 페이지)
3. userId로 해당 userId의 전체 주문 내역 조회하게 controller 수정
4. 테스트를 위해 login. html, join.html 생성
5. 업데이트 기능 추가.

![image](https://github.com/user-attachments/assets/af650afa-1838-4950-8111-6517de11a0d6)


수정
![image](https://github.com/user-attachments/assets/64e13ea2-2b2d-45e3-b281-41db232d7e31)

## PR 유형
어떤 변경 사항이 있나요?
- [X] 새로운 기능 추가
- [ ] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제